### PR TITLE
add cookie policy link

### DIFF
--- a/app/views/includes/footer.nunjucks
+++ b/app/views/includes/footer.nunjucks
@@ -16,6 +16,7 @@
         <li><a href="https://www.nhs.uk/about-us/sitemap/">Sitemap</a></li>
         <li><a href="https://www.nhs.uk/accessibility/">Accessibility</a></li>
         <li><a href="https://www.nhs.uk/our-policies/">Our policies</a></li>
+        <li><a href="https://beta.nhs.uk/our-policies/cookies-policy/">Cookie policy</a></li>
         <li>&copy; Crown Copyright</li>
       </ul>
     </div>


### PR DESCRIPTION
Add a link in the footer to beta cookies page to allow users to manage cookies on the beta domain