### PR TITLE
:phone: Fix to show service contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-0.21.0 / 2019-10-TBD
+0.21.0 / 2019-10-11
 ===================
 - Replace (deprecated) `istanbul` with `nyc`
+- Use service specific contact details
 
 0.20.0 / 2019-09-26
 ===================

--- a/app/lib/constants.js
+++ b/app/lib/constants.js
@@ -18,10 +18,12 @@ module.exports = {
     towerHamlets: '462934',
     westHampshire: '463042',
   },
-  contactMethodTypes: ['Email', 'Telephone', 'Website'],
   highlights: { post: '</span>', pre: '<span class="highlight">' },
   metrics: {
-    selfReferral: 6265,
+    IAPTEmail: 9463,
+    IAPTPhone: 9461,
+    IAPTPhoneExt: 9462,
+    IAPTUrl: 9464,
   },
   promHistogramBuckets: [0.01, 0.05, 0.1, 0.2, 0.3, 0.5, 1, 1.5, 5, 10],
   siteRoot: '/find-a-psychological-therapies-service',
@@ -29,4 +31,5 @@ module.exports = {
     GP: 'GP',
     IAPT: 'IAPT',
   },
+  websiteContactMethodType: 'Website',
 };

--- a/app/lib/mapIAPTResults.js
+++ b/app/lib/mapIAPTResults.js
@@ -1,21 +1,25 @@
 const constants = require('./constants');
 
-function mapContactMethod(input, contacts, methodType) {
-  const result = contacts.find(contact => contact.OrganisationContactMethodType === methodType);
-  if (result) {
-    // eslint-disable-next-line no-param-reassign
-    input[methodType.toLowerCase()] = result.OrganisationContactValue;
-  }
-}
-
-function mapContacts(input) {
+function mapWebsite(input) {
   if (!input.Contacts) { return; }
 
   const contacts = JSON.parse(input.Contacts);
-  const methodTypes = constants.contactMethodTypes;
   if (contacts) {
-    methodTypes.forEach(methodType => mapContactMethod(input, contacts, methodType));
+    const websiteContact = contacts.find(
+      contact => contact.OrganisationContactMethodType
+        === constants.websiteContactMethodType
+    );
+
+    if (websiteContact) {
+      // eslint-disable-next-line no-param-reassign
+      input.website = websiteContact.OrganisationContactValue;
+    }
   }
+}
+
+function metricValue(metrics, metricId) {
+  const metricToMap = metrics.find(metric => metric.MetricID === metricId);
+  return metricToMap ? metricToMap.Value : undefined;
 }
 
 function mapMetrics(input) {
@@ -23,16 +27,17 @@ function mapMetrics(input) {
 
   const metrics = JSON.parse(input.Metrics);
   if (metrics) {
-    const metric6265 = metrics.find(metric => metric.MetricID === constants.metrics.selfReferral);
-    if (metric6265) {
-      // eslint-disable-next-line no-param-reassign
-      input.selfReferral = metric6265.LinkUrl;
-    }
+    // eslint-disable-next-line no-param-reassign
+    input.telephone = metricValue(metrics, constants.metrics.IAPTPhone);
+    // eslint-disable-next-line no-param-reassign
+    input.email = metricValue(metrics, constants.metrics.IAPTEmail);
+    // eslint-disable-next-line no-param-reassign
+    input.selfReferral = metricValue(metrics, constants.metrics.IAPTUrl);
   }
 }
 
 function mapIAPTResults(input) {
-  mapContacts(input);
+  mapWebsite(input);
   mapMetrics(input);
 }
 

--- a/test/integration/iaptResultsPage.js
+++ b/test/integration/iaptResultsPage.js
@@ -75,14 +75,14 @@ describe('IAPT results page', () => {
       it('should display contact information for each result', () => {
         $('.results__item').each((i, item) => {
           const email = $(item).find('.results__email');
-          expect(email.text()).to.equal(`Email: email@result.${i}`);
+          expect(email.text()).to.equal(`Email: iapt.email@result.${i}`);
           const emailHref = getHrefFromA(email);
-          expect(emailHref).to.equal(`mailto:email@result.${i}`);
+          expect(emailHref).to.equal(`mailto:iapt.email@result.${i}`);
 
           const tel = $(item).find('.results__telephone');
-          expect(tel.text()).to.equal(`Telephone: result ${i} telephone`);
+          expect(tel.text()).to.equal(`Telephone: result ${i} IAPT telephone`);
           const telHref = getHrefFromA(tel);
-          expect(telHref).to.equal(`tel:result ${i} telephone`);
+          expect(telHref).to.equal(`tel:result ${i} IAPT telephone`);
 
           const orgName = $(item).find('.results__name').text();
           const website = $(item).find('.results__website');
@@ -97,8 +97,8 @@ describe('IAPT results page', () => {
         expect(selfReferralElements.length).to.equal(2);
         const selfReferralElement0Href = getHrefFromA(selfReferralElements.eq(0));
         const selfReferralElement2Href = getHrefFromA(selfReferralElements.eq(1));
-        expect(selfReferralElement0Href).to.equal('https://self.referral.0');
-        expect(selfReferralElement2Href).to.equal('https://self.referral.2');
+        expect(selfReferralElement0Href).to.equal('https://iapt.self.referral.0');
+        expect(selfReferralElement2Href).to.equal('https://iapt.self.referral.2');
       });
 
       it('should display no message about online referrals not being available when there is no available option', () => {

--- a/test/resources/responses/search/threeResults.json
+++ b/test/resources/responses/search/threeResults.json
@@ -18,7 +18,7 @@
         "NHS Leeds North CCG"
       ],
       "Contacts": "[{\"OrganisationContactMethodType\":\"Telephone\",\"OrganisationContactValue\":\"result 0 telephone\"},{\"OrganisationContactMethodType\":\"Email\",\"OrganisationContactValue\":\"email@result.0\"},{\"OrganisationContactMethodType\":\"Website\",\"OrganisationContactValue\":\"https:\\/\\/website.result.0\"}]",
-      "Metrics": "[{\"MetricID\":6265,\"MetricName\":\"IAPT self-referral\",\"DisplayName\":\"Offers self-referral\",\"Description\":\"Whether the service offers self-referral for IAPT\",\"Value\":\"\",\"LinkUrl\":\"https:\\/\\/self.referral.0\",\"LinkText\":\"Click here to access self-referral form\",\"MetricDisplayTypeID\":5,\"MetricDisplayTypeName\":\"BandingImage\",\"HospitalSectorType\":\"Independent Sector\",\"MetricText\":\"[BandingName]\"}]"
+      "Metrics": "[{\"MetricID\":9461,\"MetricName\":\"IAPT Phone\",\"DisplayName\":\"IAPT Phone\",\"Description\":\"IAPT Phone\",\"Value\":\"result 0 IAPT telephone\",\"MetricDisplayTypeID\":2,\"MetricDisplayTypeName\":\"Value\",\"IsMetaMetric\":false},{\"MetricID\":9462,\"MetricName\":\"IAPT Phone Ext\",\"DisplayName\":\"IAPT Phone Ext\",\"Description\":\"IAPT Phone Ext\",\"Value\":\"result 0 IAPT telephone ext\",\"MetricDisplayTypeID\":2,\"MetricDisplayTypeName\":\"Value\",\"IsMetaMetric\":false},{\"MetricID\":9463,\"MetricName\":\"IAPT Email\",\"DisplayName\":\"IAPT Email\",\"Description\":\"IAPT Email\",\"Value\":\"iapt.email@result.0\",\"MetricDisplayTypeID\":2,\"MetricDisplayTypeName\":\"Value\",\"IsMetaMetric\":false},{\"MetricID\":9464,\"MetricName\":\"IAPT URL\",\"DisplayName\":\"IAPT URL\",\"Description\":\"IAPT URL\",\"Value\":\"https://iapt.self.referral.0\",\"MetricDisplayTypeID\":7,\"MetricDisplayTypeName\":\"HtmlText\",\"IsMetaMetric\":false}]"
     },
     {
       "@search.text": "LS12 3HD",
@@ -36,7 +36,8 @@
         "463248",
         "NHS Leeds West CCG"
       ],
-      "Contacts": "[{\"OrganisationContactMethodType\":\"Telephone\",\"OrganisationContactValue\":\"result 1 telephone\"},{\"OrganisationContactMethodType\":\"Email\",\"OrganisationContactValue\":\"email@result.1\"},{\"OrganisationContactMethodType\":\"Website\",\"OrganisationContactValue\":\"https:\\/\\/website.result.1\"}]"
+      "Contacts": "[{\"OrganisationContactMethodType\":\"Telephone\",\"OrganisationContactValue\":\"result 1 telephone\"},{\"OrganisationContactMethodType\":\"Email\",\"OrganisationContactValue\":\"email@result.1\"},{\"OrganisationContactMethodType\":\"Website\",\"OrganisationContactValue\":\"https:\\/\\/website.result.1\"}]",
+      "Metrics": "[{\"MetricID\":9461,\"MetricName\":\"IAPT Phone\",\"DisplayName\":\"IAPT Phone\",\"Description\":\"IAPT Phone\",\"Value\":\"result 1 IAPT telephone\",\"MetricDisplayTypeID\":2,\"MetricDisplayTypeName\":\"Value\",\"IsMetaMetric\":false},{\"MetricID\":9462,\"MetricName\":\"IAPT Phone Ext\",\"DisplayName\":\"IAPT Phone Ext\",\"Description\":\"IAPT Phone Ext\",\"Value\":\"result 1 IAPT telephone ext\",\"MetricDisplayTypeID\":2,\"MetricDisplayTypeName\":\"Value\",\"IsMetaMetric\":false},{\"MetricID\":9463,\"MetricName\":\"IAPT Email\",\"DisplayName\":\"IAPT Email\",\"Description\":\"IAPT Email\",\"Value\":\"iapt.email@result.1\",\"MetricDisplayTypeID\":2,\"MetricDisplayTypeName\":\"Value\",\"IsMetaMetric\":false}]"
     },
     {
       "@search.text": "LS17 8AE",
@@ -53,7 +54,7 @@
         "NHS Leeds North CCG"
       ],
       "Contacts": "[{\"OrganisationContactMethodType\":\"Telephone\",\"OrganisationContactValue\":\"result 2 telephone\"},{\"OrganisationContactMethodType\":\"Email\",\"OrganisationContactValue\":\"email@result.2\"},{\"OrganisationContactMethodType\":\"Website\",\"OrganisationContactValue\":\"https:\\/\\/website.result.2\"}]",
-      "Metrics": "[{\"MetricID\":6265,\"MetricName\":\"IAPT self-referral\",\"DisplayName\":\"Offers self-referral\",\"Description\":\"Whether the service offers self-referral for IAPT\",\"Value\":\"\",\"LinkUrl\":\"https:\\/\\/self.referral.2\",\"LinkText\":\"Click here to access self-referral form\",\"MetricDisplayTypeID\":5,\"MetricDisplayTypeName\":\"BandingImage\",\"HospitalSectorType\":\"Independent Sector\",\"MetricText\":\"[BandingName]\"}]"
+      "Metrics": "[{\"MetricID\":9461,\"MetricName\":\"IAPT Phone\",\"DisplayName\":\"IAPT Phone\",\"Description\":\"IAPT Phone\",\"Value\":\"result 2 IAPT telephone\",\"MetricDisplayTypeID\":2,\"MetricDisplayTypeName\":\"Value\",\"IsMetaMetric\":false},{\"MetricID\":9462,\"MetricName\":\"IAPT Phone Ext\",\"DisplayName\":\"IAPT Phone Ext\",\"Description\":\"IAPT Phone Ext\",\"Value\":\"result 2 IAPT telephone ext\",\"MetricDisplayTypeID\":2,\"MetricDisplayTypeName\":\"Value\",\"IsMetaMetric\":false},{\"MetricID\":9463,\"MetricName\":\"IAPT Email\",\"DisplayName\":\"IAPT Email\",\"Description\":\"IAPT Email\",\"Value\":\"iapt.email@result.2\",\"MetricDisplayTypeID\":2,\"MetricDisplayTypeName\":\"Value\",\"IsMetaMetric\":false},{\"MetricID\":9464,\"MetricName\":\"IAPT URL\",\"DisplayName\":\"IAPT URL\",\"Description\":\"IAPT URL\",\"Value\":\"https://iapt.self.referral.2\",\"MetricDisplayTypeID\":7,\"MetricDisplayTypeName\":\"HtmlText\",\"IsMetaMetric\":false}]"
     }
   ]
 }

--- a/test/unit/lib/mapIAPTResults.js
+++ b/test/unit/lib/mapIAPTResults.js
@@ -1,5 +1,5 @@
 const chai = require('chai');
-
+const constants = require('../../../app/lib/constants');
 const mapIAPTResults = require('../../../app/lib/mapIAPTResults');
 
 const expect = chai.expect;
@@ -37,17 +37,18 @@ describe('mapIAPTResults', () => {
 
     const email = 'name@domain.com';
     const telephone = '0800 123 456';
+    const telephoneExt = '987';
     const website = 'https://a.web.site';
     const linkUrl = 'https://self.referral.com';
     const contacts = [
-      { OrganisationContactMethodType: 'Telephone', OrganisationContactValue: telephone },
-      { OrganisationContactMethodType: 'Email', OrganisationContactValue: email },
       { OrganisationContactMethodType: 'Website', OrganisationContactValue: website },
     ];
-    const metrics = [{
-      LinkUrl: linkUrl,
-      MetricID: 6265,
-    }];
+    const metrics = [
+      { MetricID: constants.metrics.IAPTPhone, Value: telephone },
+      { MetricID: constants.metrics.IAPTPhoneExt, Value: telephoneExt },
+      { MetricID: constants.metrics.IAPTEmail, Value: email },
+      { MetricID: constants.metrics.IAPTUrl, Value: linkUrl },
+    ];
 
     before('execute function', () => {
       input = { Contacts: JSON.stringify(contacts), Metrics: JSON.stringify(metrics) };

--- a/test/unit/lib/mapIAPTResults.js
+++ b/test/unit/lib/mapIAPTResults.js
@@ -1,5 +1,5 @@
 const chai = require('chai');
-const constants = require('../../../app/lib/constants');
+const { metrics } = require('../../../app/lib/constants');
 const mapIAPTResults = require('../../../app/lib/mapIAPTResults');
 
 const expect = chai.expect;
@@ -43,15 +43,18 @@ describe('mapIAPTResults', () => {
     const contacts = [
       { OrganisationContactMethodType: 'Website', OrganisationContactValue: website },
     ];
-    const metrics = [
-      { MetricID: constants.metrics.IAPTPhone, Value: telephone },
-      { MetricID: constants.metrics.IAPTPhoneExt, Value: telephoneExt },
-      { MetricID: constants.metrics.IAPTEmail, Value: email },
-      { MetricID: constants.metrics.IAPTUrl, Value: linkUrl },
+    const inputMetrics = [
+      { MetricID: metrics.IAPTPhone, Value: telephone },
+      { MetricID: metrics.IAPTPhoneExt, Value: telephoneExt },
+      { MetricID: metrics.IAPTEmail, Value: email },
+      { MetricID: metrics.IAPTUrl, Value: linkUrl },
     ];
 
     before('execute function', () => {
-      input = { Contacts: JSON.stringify(contacts), Metrics: JSON.stringify(metrics) };
+      input = {
+        Contacts: JSON.stringify(contacts),
+        Metrics: JSON.stringify(inputMetrics),
+      };
 
       mapIAPTResults(input);
     });

--- a/test/unit/lib/mapResults.js
+++ b/test/unit/lib/mapResults.js
@@ -2,9 +2,8 @@ const chai = require('chai');
 const VError = require('verror');
 
 const mapResults = require('../../../app/lib/mapResults');
-const constants = require('../../../app/lib/constants');
+const { metrics, types } = require('../../../app/lib/constants');
 
-const types = constants.types;
 const expect = chai.expect;
 
 describe('mapResults', () => {
@@ -86,14 +85,14 @@ describe('mapResults', () => {
       const contacts = JSON.stringify([
         { OrganisationContactMethodType: 'Website', OrganisationContactValue: website },
       ]);
-      const metrics = JSON.stringify([
-        { MetricID: constants.metrics.IAPTPhone, Value: telephone },
-        { MetricID: constants.metrics.IAPTEmail, Value: email },
+      const inputMetrics = JSON.stringify([
+        { MetricID: metrics.IAPTPhone, Value: telephone },
+        { MetricID: metrics.IAPTEmail, Value: email },
       ]);
       const someValue = {
         value: [
-          { Contacts: contacts, Metrics: metrics },
-          { Contacts: contacts, Metrics: metrics },
+          { Contacts: contacts, Metrics: inputMetrics },
+          { Contacts: contacts, Metrics: inputMetrics },
         ],
       };
 

--- a/test/unit/lib/mapResults.js
+++ b/test/unit/lib/mapResults.js
@@ -2,8 +2,9 @@ const chai = require('chai');
 const VError = require('verror');
 
 const mapResults = require('../../../app/lib/mapResults');
-const types = require('../../../app/lib/constants').types;
+const constants = require('../../../app/lib/constants');
 
+const types = constants.types;
 const expect = chai.expect;
 
 describe('mapResults', () => {
@@ -67,7 +68,7 @@ describe('mapResults', () => {
   describe('for IAPT type', () => {
     const type = types.IAPT;
 
-    it('should not add a property for \'email\', \'telephone\' or \'website\' when there information', () => {
+    it('should not add a property for \'email\', \'telephone\' or \'website\' when no information', () => {
       const noValue = '{ "value": [{},{}] }';
       const results = mapResults(noValue, type);
 
@@ -78,18 +79,25 @@ describe('mapResults', () => {
       results.forEach(item => expect(item.website).to.be.undefined);
     });
 
-    it('should add a property for \'email\', \'telephone\' or \'website\' when there information', () => {
+    it('should add a property for \'email\', \'telephone\' or \'website\' when there is information', () => {
       const email = 'name@domain.com';
       const telephone = '0800 123 456';
       const website = 'https://a.web.site';
       const contacts = JSON.stringify([
-        { OrganisationContactMethodType: 'Telephone', OrganisationContactValue: telephone },
-        { OrganisationContactMethodType: 'Email', OrganisationContactValue: email },
         { OrganisationContactMethodType: 'Website', OrganisationContactValue: website },
       ]);
-      const noValue = { value: [{ Contacts: contacts }, { Contacts: contacts }] };
+      const metrics = JSON.stringify([
+        { MetricID: constants.metrics.IAPTPhone, Value: telephone },
+        { MetricID: constants.metrics.IAPTEmail, Value: email },
+      ]);
+      const someValue = {
+        value: [
+          { Contacts: contacts, Metrics: metrics },
+          { Contacts: contacts, Metrics: metrics },
+        ],
+      };
 
-      const results = mapResults(JSON.stringify(noValue), type);
+      const results = mapResults(JSON.stringify(someValue), type);
 
       expect(results).to.be.an('array');
       expect(results.length).to.equal(2);


### PR DESCRIPTION
## Description
Contact details being used were the organisation contact details which in most  cases are not the same as the IAPT service specific contact details.
Telephone and email address now fetched from the IAPT contact details metrics. Self-referral URL now also from a new metric. Main website URL still fetched from organisation contact details.
New metrics also include a metric for the telephone extension number. This metric has been added to the constants, and set in test data, but is not currently displayed.