### PR TITLE
Refactor internal navigation to use routes

### DIFF
--- a/app/middleware/locals.js
+++ b/app/middleware/locals.js
@@ -3,6 +3,7 @@ const constants = require('../lib/constants');
 const digitalData = require('../lib/digitalData');
 const search = require('../../config/config').search;
 const trim = require('../lib/utils/utils').trim;
+const routes = require('../../config/routes');
 
 function getQuery(type, query) {
   return type === constants.types.IAPT ? query.ccgid : query.query;
@@ -21,6 +22,7 @@ module.exports = config => (req, res, next) => {
   res.locals.canonicalUrl = canonicalUrl(req);
   res.locals.digitalData = digitalData(req);
   res.locals.siteRoot = constants.siteRoot;
+  res.locals.routes = routes;
 
   res.locals.location = trim(req.query.location);
   const type = req.query.type && req.query.type.toUpperCase();

--- a/app/views/check.nunjucks
+++ b/app/views/check.nunjucks
@@ -14,7 +14,7 @@
 		text: "Services near you"
 		}
 		],
-		href: siteRoot,
+		href: siteRoot + routes.start.path,
 		text: "Find a psychological therapies service"
 	}) }}
 {% endblock %}
@@ -32,11 +32,11 @@
 
 {{ button({
   "text": "Continue",
-  "href": siteRoot + "/search"
+  "href": siteRoot + routes.search.path
 }) }}
 
 {{ backLink({
-  "href": siteRoot,
+  "href": siteRoot + routes.start.path,
   "text": "Go back"
 }) }}
 

--- a/app/views/error-404.nunjucks
+++ b/app/views/error-404.nunjucks
@@ -14,7 +14,7 @@
 		text: "Services near you"
 		}
 		],
-		href: siteRoot,
+		href: siteRoot + routes.start.path,
 		text: "Find a psychological therapies service"
 	}) }}
 {% endblock %}

--- a/app/views/error.nunjucks
+++ b/app/views/error.nunjucks
@@ -16,7 +16,7 @@
 		text: "Services near you"
 		}
 		],
-		href: siteRoot,
+		href: siteRoot + routes.start.path,
 		text: "Find a psychological therapies service"
 	}) }}
 {% endblock %}

--- a/app/views/gp-results.nunjucks
+++ b/app/views/gp-results.nunjucks
@@ -1,5 +1,5 @@
 {% extends 'layout.nunjucks' %}
-{% set href = siteRoot + "/search?query=" + query | urlencode %}
+{% set href = siteRoot + routes.search.path + "?query=" + query | urlencode %}
 {% set msg = "Sorry, we couldn\'t find any GP surgeries matching \'" + query + "\'" %}
 
 {% block pageTitle %}{% if results.length > 0 %}Select your GP{% else %}{{ msg }}{% endif %}{% endblock %}
@@ -16,7 +16,7 @@
 		text: "Services near you"
 		}
 		],
-		href: siteRoot,
+		href: siteRoot + routes.start.path,
 		text: "Find a psychological therapies service"
 	}) }}
 {% endblock %}

--- a/app/views/iapt-results.nunjucks
+++ b/app/views/iapt-results.nunjucks
@@ -2,9 +2,9 @@
 {% set resultsLength = results.length %}
 {% set msg = 'There are no services available for \'' + gpname + '\'' %}
 {% if origin === 'search' %}
-{% set href = siteRoot + "/search?query=" + gpquery | urlencode %}
+{% set href = siteRoot + routes.search.path + "?query=" + gpquery | urlencode %}
 {% else %}
-{% set href = siteRoot + "/results?type=gp&query=" + gpquery | urlencode %}
+{% set href = siteRoot + routes.results.path + "?type=gp&query=" + gpquery | urlencode %}
 {% endif %}
 
 {% block pageTitle %}{% if results.length > 0 %}Services you can refer yourself to{% else %}{{ msg }}{% endif %}{% endblock %}
@@ -21,7 +21,7 @@
 		text: "Services near you"
 		}
 		],
-		href: siteRoot,
+		href: siteRoot + routes.start.path,
 		text: "Find a psychological therapies service"
 	}) }}
 {% endblock %}
@@ -57,9 +57,9 @@
   <p class="no-results">No results</p>
 {% endif %}
 {% if origin === 'search' %}
-{% set href = siteRoot + "/search?query=" + gpquery | urlencode %}
+{% set href = siteRoot + routes.search.path + "?query=" + gpquery | urlencode %}
 {% else %}
-{% set href = siteRoot + "/results?type=gp&query=" + gpquery | urlencode %}
+{% set href = siteRoot + routes.results.path + "?type=gp&query=" + gpquery | urlencode %}
 {% endif %}
 {{ backLink({
   "href": href,

--- a/app/views/includes/gp-result-item.nunjucks
+++ b/app/views/includes/gp-result-item.nunjucks
@@ -4,7 +4,7 @@
   <p class="results__address" role="text">{{ result.fullAddress | safe }}</p>
 {% endif %}
 
-<p><a class="results__gp__selection" href="{{ siteRoot }}/results?type=iapt&ccgid={{ result.CCG[0] }}&gpquery={{ query | urlencode }}&gpname={{ result.OrganisationName | urlencode }}&lat={{ result.Latitude }}&lon={{ result.Longitude }}">
+<p><a class="results__gp__selection" href="{{ siteRoot }}{{ routes.results.path }}?type=iapt&ccgid={{ result.CCG[0] }}&gpquery={{ query | urlencode }}&gpname={{ result.OrganisationName | urlencode }}&lat={{ result.Latitude }}&lon={{ result.Longitude }}">
   <span class="nhsuk-u-visually-hidden">{{ result.OrganisationName }}</span>
   <span aria-hidden="true">This</span> is my GP</a>
 </p>

--- a/app/views/search.nunjucks
+++ b/app/views/search.nunjucks
@@ -16,7 +16,7 @@
 		text: "Services near you"
 		}
 		],
-		href: siteRoot,
+		href: siteRoot + routes.start.path,
 		text: "Find a psychological therapies service"
 	}) }}
 {% endblock %}
@@ -25,7 +25,7 @@
 
 <h1>We need to know where your GP is</h1>
 
-<form method="get" class="form" action="{{ siteRoot }}/results">
+<form method="get" class="form" action="{{ siteRoot }}{{ routes.results.path }}">
   <input type="hidden" id="type" name="type" value="gp" />
   <input type="hidden" id="gpquery" name="gpquery" value="" />
   <input type="hidden" id="gpname" name="gpname" value="" />
@@ -61,7 +61,7 @@
   }) }}
 
   {{ backLink({
-    "href": siteRoot + "/check",
+    "href": siteRoot + routes.check.path,
     "text": "Go back"
   }) }}
   

--- a/app/views/start.nunjucks
+++ b/app/views/start.nunjucks
@@ -35,7 +35,7 @@
 
 {{ button({
   "text": "Start now",
-  "href": siteRoot + "/check"
+  "href": siteRoot + routes.check.path
 }) }}
 
 {{ warningCallout({

--- a/config/express.js
+++ b/config/express.js
@@ -11,6 +11,7 @@ const helmet = require('./helmet');
 const log = require('../app/lib/logger');
 const promBundle = require('../app/lib/prometheus/bundle').middleware;
 const router = require('./router');
+const { path: startPath } = require('./routes').start;
 
 module.exports = (app, config) => {
   // start collecting default metrics
@@ -79,6 +80,6 @@ module.exports = (app, config) => {
   });
 
   app.get('/', (req, res) => {
-    res.redirect(constants.siteRoot);
+    res.redirect(constants.siteRoot + startPath);
   });
 };

--- a/test/integration/app.js
+++ b/test/integration/app.js
@@ -2,6 +2,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 
 const constants = require('../../app/lib/constants');
+const { path: startPath } = require('../../config/routes').start;
 const server = require('../../server');
 
 const expect = chai.expect;
@@ -9,12 +10,12 @@ const expect = chai.expect;
 chai.use(chaiHttp);
 
 describe('Application behaviour', () => {
-  it('should redirect root requests to /find-a-psychological-therapies-service', async () => {
+  it('should redirect root requests to start page', async () => {
     const res = await chai.request(server).get('/');
     expect(res).to.have.status(200);
     expect(res).to.be.html;
     expect(res).to.redirect;
-    expect(res.req.path).to.equal(`${constants.siteRoot}/`);
+    expect(res.req.path).to.equal(`${constants.siteRoot}${startPath}`);
   });
 
   it('should have or have not headers for security', async () => {

--- a/test/integration/checkPage.js
+++ b/test/integration/checkPage.js
@@ -26,6 +26,6 @@ describe('Check page', () => {
   });
 
   it('has a back link to the start page', () => {
-    iExpect.backLinkContent($, constants.siteRoot);
+    iExpect.backLinkContent($, constants.siteRoot + routes.start.path);
   });
 });

--- a/test/integration/pageLinksBackToChoices.js
+++ b/test/integration/pageLinksBackToChoices.js
@@ -20,7 +20,7 @@ describe('Page links back to Choices', () => {
     const res = await chai.request(server).get(`${constants.siteRoot}${path}`);
 
     describe(`for page ${path}`, () => {
-      it('the breadcrumbs should have 2 levels of links', () => {
+      it('the breadcrumbs should have correct levels of links', () => {
         const $ = cheerio.load(res.text);
         iExpect.breadcrumbContent($, path);
       });

--- a/test/integration/startPage.js
+++ b/test/integration/startPage.js
@@ -14,7 +14,7 @@ describe('Start page', () => {
   let $;
 
   before('request page', async () => {
-    const res = await chai.request(server).get(`${constants.siteRoot}`);
+    const res = await chai.request(server).get(`${constants.siteRoot}${routes.start.path}`);
 
     $ = cheerio.load(res.text);
   });

--- a/test/lib/expectations.js
+++ b/test/lib/expectations.js
@@ -1,6 +1,7 @@
 const chai = require('chai');
 const cheerio = require('cheerio');
 const constants = require('../../app/lib/constants');
+const { path: startPath } = require('../../config/routes').start;
 
 const expect = chai.expect;
 
@@ -14,9 +15,9 @@ function breadcrumbContent($, path) {
   expect($('.nhsuk-breadcrumb__item').eq(0).find('a').prop('href')).to.equal('https://www.nhs.uk');
   expect($('.nhsuk-breadcrumb__item').eq(1).text().trim()).to.equal('Services near you');
   expect($('.nhsuk-breadcrumb__item').eq(1).find('a').prop('href')).to.equal('https://www.nhs.uk/service-search');
-  if (path !== '/') {
+  if (path !== startPath) {
     expect($('.nhsuk-breadcrumb__item').eq(2).text().trim()).to.equal('Find a psychological therapies service');
-    expect($('.nhsuk-breadcrumb__item').eq(2).find('a').prop('href')).to.equal(constants.siteRoot);
+    expect($('.nhsuk-breadcrumb__item').eq(2).find('a').prop('href')).to.equal(constants.siteRoot + startPath);
   }
 }
 


### PR DESCRIPTION
Draft pull request to get feedback on refactoring. This refactoring is a precursor to changing the route paths, e.g. `check` will become `what-happens-when-you-refer-yourself`. Changes made on top of feature/update-frontend-library instead of master as former branch includes extensive changes to views.

Navigation links/URLs in the views, such as back and next links and form action URL have hard-coded paths that would all needed to be updated if changes made to the routing.
To reduce future maintenance, this refactoring replaces the hard-coded paths with references to the `routes` object. Implicit uses of the start path (`/`) have been replaced with `routes.start.path`.