### PR TITLE
Routing path changes

### DIFF
--- a/app/lib/constants.js
+++ b/app/lib/constants.js
@@ -26,7 +26,7 @@ module.exports = {
     IAPTUrl: 9464,
   },
   promHistogramBuckets: [0.01, 0.05, 0.1, 0.2, 0.3, 0.5, 1, 1.5, 5, 10],
-  siteRoot: '/find-a-psychological-therapies-service',
+  siteRoot: '/service-search/find-a-psychological-therapies-service',
   types: {
     GP: 'GP',
     IAPT: 'IAPT',

--- a/app/lib/digitalData.js
+++ b/app/lib/digitalData.js
@@ -1,9 +1,10 @@
-function getPageName(path) {
-  return `nhs:beta${path.replace(/\/$/, '').replace(/\//g, ':')}`;
+function getPageName(categories) {
+  return `nhs:web:${categories.join(':')}`;
 }
 
 function getCategories(path) {
-  return path.split('/').filter(Boolean);
+  // Max 4 categories, additional URL segments are ignored
+  return path.split('/').filter(Boolean).splice(0, 4);
 }
 
 function digitalData(req) {
@@ -18,7 +19,7 @@ function digitalData(req) {
         subCategory3: categories[3],
       },
       pageInfo: {
-        pageName: getPageName(path),
+        pageName: getPageName(categories),
       },
     },
   };

--- a/config/routes.js
+++ b/config/routes.js
@@ -1,7 +1,7 @@
 module.exports = {
   check: {
     h1: 'What happens when you refer yourself',
-    path: '/check',
+    path: '/what-happens-when-you-refer-yourself',
     title: 'What happens next',
   },
   results: {
@@ -9,7 +9,7 @@ module.exports = {
   },
   search: {
     h1: 'We need to know where your GP is',
-    path: '/search',
+    path: '/find-your-gp',
     title: 'Search for your GP',
   },
   start: {

--- a/rancher-config/rancher-compose.yml
+++ b/rancher-config/rancher-compose.yml
@@ -13,5 +13,5 @@ services:
       initializing_timeout: 60000
       interval: 5000
       strategy: recreate
-      request_line: GET "/find-a-psychological-therapies-service/?check" "HTTP/1.0"
+      request_line: GET "/service-search/find-a-psychological-therapies-service/?check" "HTTP/1.0"
       reinitializing_timeout: 60000

--- a/test/performance/iapt-finder.jmx
+++ b/test/performance/iapt-finder.jmx
@@ -131,7 +131,7 @@
             <stringProp name="HTTPSampler.port"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/find-a-psychological-therapies-service/check</stringProp>
+            <stringProp name="HTTPSampler.path">/find-a-psychological-therapies-service/what-happens-when-you-refer-yourself</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -152,7 +152,7 @@
             <stringProp name="HTTPSampler.port"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/find-a-psychological-therapies-service/search</stringProp>
+            <stringProp name="HTTPSampler.path">/find-a-psychological-therapies-service/find-your-gp</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/test/unit/lib/digitalData.js
+++ b/test/unit/lib/digitalData.js
@@ -6,12 +6,13 @@ const digitalData = require('../../../app/lib/digitalData');
 const expect = chai.expect;
 
 describe('digitalData', () => {
-  const siteRootPath = siteRoot.substring(1);
+  // assumes siteRoot contains two segments
+  const [ primaryCategory, subCategory1 ] = siteRoot.split('/').filter(Boolean);
   const secondLevelPath = 'second';
   const thirdLevelPath = 'third';
   const fourthLevelPath = 'fourth';
 
-  it('should contain primaryCategory only for site root', () => {
+  it('should contain primaryCategory and subCategory1 for site root', () => {
     const req = { path: `${siteRoot}/` };
 
     const dd = digitalData(req);
@@ -20,19 +21,19 @@ describe('digitalData', () => {
     expect(dd).to.have.property('page');
     expect(dd.page).to.have.property('category');
     expect(dd.page.category).to.have.property('primaryCategory');
-    expect(dd.page.category.primaryCategory).to.equal(siteRootPath);
+    expect(dd.page.category.primaryCategory).to.equal(primaryCategory);
     expect(dd.page.category).to.have.property('subCategory1');
-    expect(dd.page.category.subCategory1).to.be.undefined;
+    expect(dd.page.category.subCategory1).to.equal(subCategory1);
     expect(dd.page.category).to.have.property('subCategory2');
     expect(dd.page.category.subCategory2).to.be.undefined;
     expect(dd.page.category).to.have.property('subCategory3');
     expect(dd.page.category.subCategory3).to.be.undefined;
     expect(dd.page).to.have.property('pageInfo');
     expect(dd.page.pageInfo).to.have.property('pageName');
-    expect(dd.page.pageInfo.pageName).to.equal(`nhs:beta:${siteRootPath}`);
+    expect(dd.page.pageInfo.pageName).to.equal(`nhs:web:${primaryCategory}:${subCategory1}`);
   });
 
-  it('should contain 2 categories for second level pages', () => {
+  it('should contain 3 categories for second level pages', () => {
     const req = { path: `${siteRoot}/${secondLevelPath}` };
 
     const dd = digitalData(req);
@@ -41,19 +42,20 @@ describe('digitalData', () => {
     expect(dd).to.have.property('page');
     expect(dd.page).to.have.property('category');
     expect(dd.page.category).to.have.property('primaryCategory');
-    expect(dd.page.category.primaryCategory).to.equal(siteRootPath);
+    expect(dd.page.category.primaryCategory).to.equal(primaryCategory);
     expect(dd.page.category).to.have.property('subCategory1');
-    expect(dd.page.category.subCategory1).to.equal(secondLevelPath);
+    expect(dd.page.category.subCategory1).to.equal(subCategory1);
     expect(dd.page.category).to.have.property('subCategory2');
-    expect(dd.page.category.subCategory2).to.be.undefined;
+    expect(dd.page.category.subCategory2).to.equal(secondLevelPath);
     expect(dd.page.category).to.have.property('subCategory3');
     expect(dd.page.category.subCategory3).to.be.undefined;
     expect(dd.page).to.have.property('pageInfo');
     expect(dd.page.pageInfo).to.have.property('pageName');
-    expect(dd.page.pageInfo.pageName).to.equal(`nhs:beta:${siteRootPath}:${secondLevelPath}`);
+    expect(dd.page.pageInfo.pageName).to.equal(
+      `nhs:web:${primaryCategory}:${subCategory1}:${secondLevelPath}`);
   });
 
-  it('should contain 3 categories for third level pages', () => {
+  it('should contain 4 categories for third level pages', () => {
     const req = { path: `${siteRoot}/${secondLevelPath}/${thirdLevelPath}` };
 
     const dd = digitalData(req);
@@ -62,18 +64,20 @@ describe('digitalData', () => {
     expect(dd).to.have.property('page');
     expect(dd.page).to.have.property('category');
     expect(dd.page.category).to.have.property('primaryCategory');
-    expect(dd.page.category.primaryCategory).to.equal(siteRootPath);
+    expect(dd.page.category.primaryCategory).to.equal(primaryCategory);
     expect(dd.page.category).to.have.property('subCategory1');
-    expect(dd.page.category.subCategory1).to.equal(secondLevelPath);
+    expect(dd.page.category.subCategory1).to.equal(subCategory1);
     expect(dd.page.category).to.have.property('subCategory2');
-    expect(dd.page.category.subCategory2).to.equal(thirdLevelPath);
+    expect(dd.page.category.subCategory2).to.equal(secondLevelPath);
     expect(dd.page.category).to.have.property('subCategory3');
-    expect(dd.page.category.subCategory3).to.be.undefined;
+    expect(dd.page.category.subCategory3).to.equal(thirdLevelPath);
     expect(dd.page).to.have.property('pageInfo');
     expect(dd.page.pageInfo).to.have.property('pageName');
-    expect(dd.page.pageInfo.pageName).to.equal(`nhs:beta:${siteRootPath}:${secondLevelPath}:${thirdLevelPath}`);
+    expect(dd.page.pageInfo.pageName).to.equal(
+      `nhs:web:${primaryCategory}:${subCategory1}:${secondLevelPath}:${thirdLevelPath}`);
   });
 
+  // max of 4 categories - extra levels are ignored
   it('should contain 4 categories for fourth level pages', () => {
     const req = { path: `${siteRoot}/${secondLevelPath}/${thirdLevelPath}/${fourthLevelPath}` };
 
@@ -83,15 +87,16 @@ describe('digitalData', () => {
     expect(dd).to.have.property('page');
     expect(dd.page).to.have.property('category');
     expect(dd.page.category).to.have.property('primaryCategory');
-    expect(dd.page.category.primaryCategory).to.equal(siteRootPath);
+    expect(dd.page.category.primaryCategory).to.equal(primaryCategory);
     expect(dd.page.category).to.have.property('subCategory1');
-    expect(dd.page.category.subCategory1).to.equal(secondLevelPath);
+    expect(dd.page.category.subCategory1).to.equal(subCategory1);
     expect(dd.page.category).to.have.property('subCategory2');
-    expect(dd.page.category.subCategory2).to.equal(thirdLevelPath);
+    expect(dd.page.category.subCategory2).to.equal(secondLevelPath);
     expect(dd.page.category).to.have.property('subCategory3');
-    expect(dd.page.category.subCategory3).to.equal(fourthLevelPath);
+    expect(dd.page.category.subCategory3).to.equal(thirdLevelPath);
     expect(dd.page).to.have.property('pageInfo');
     expect(dd.page.pageInfo).to.have.property('pageName');
-    expect(dd.page.pageInfo.pageName).to.equal(`nhs:beta:${siteRootPath}:${secondLevelPath}:${thirdLevelPath}:${fourthLevelPath}`);
+    expect(dd.page.pageInfo.pageName).to.equal(
+      `nhs:web:${primaryCategory}:${subCategory1}:${secondLevelPath}:${thirdLevelPath}`);
   });
 });

--- a/test/unit/lib/digitalData.js
+++ b/test/unit/lib/digitalData.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 
 describe('digitalData', () => {
   // assumes siteRoot contains two segments
-  const [ primaryCategory, subCategory1 ] = siteRoot.split('/').filter(Boolean);
+  const [primaryCategory, subCategory1] = siteRoot.split('/').filter(Boolean);
   const secondLevelPath = 'second';
   const thirdLevelPath = 'third';
   const fourthLevelPath = 'fourth';
@@ -52,7 +52,8 @@ describe('digitalData', () => {
     expect(dd.page).to.have.property('pageInfo');
     expect(dd.page.pageInfo).to.have.property('pageName');
     expect(dd.page.pageInfo.pageName).to.equal(
-      `nhs:web:${primaryCategory}:${subCategory1}:${secondLevelPath}`);
+      `nhs:web:${primaryCategory}:${subCategory1}:${secondLevelPath}`
+    );
   });
 
   it('should contain 4 categories for third level pages', () => {
@@ -74,7 +75,8 @@ describe('digitalData', () => {
     expect(dd.page).to.have.property('pageInfo');
     expect(dd.page.pageInfo).to.have.property('pageName');
     expect(dd.page.pageInfo.pageName).to.equal(
-      `nhs:web:${primaryCategory}:${subCategory1}:${secondLevelPath}:${thirdLevelPath}`);
+      `nhs:web:${primaryCategory}:${subCategory1}:${secondLevelPath}:${thirdLevelPath}`
+    );
   });
 
   // max of 4 categories - extra levels are ignored
@@ -97,6 +99,7 @@ describe('digitalData', () => {
     expect(dd.page).to.have.property('pageInfo');
     expect(dd.page.pageInfo).to.have.property('pageName');
     expect(dd.page.pageInfo.pageName).to.equal(
-      `nhs:web:${primaryCategory}:${subCategory1}:${secondLevelPath}:${thirdLevelPath}`);
+      `nhs:web:${primaryCategory}:${subCategory1}:${secondLevelPath}:${thirdLevelPath}`
+    );
   });
 });


### PR DESCRIPTION
Updated paths to be included with first full release.
Changes made on top of feature/update-frontend-library as those changes intended for release before this one. Base set as feature/update-frontend-library for ease of comparison but do not intend to merge into that branch - will need to rebase against master after frontend changes merged.

Paths have been changed as follows:

1. siteRoot prefixed with /service-search
2. check -> what-happens-when-you-refer-yourself
3. search -> find-your-gp

Tests for digitalData updated to reflect automatic changes due to path changes.
pageName in digitalData updated to include 'web' instead of 'beta'.

Note: paths have been changed in performance test configuration but have not been modified/fixed to include latitude and longitude. Currently a separate branch/PR for the performance test fixes as might want to release the test fixes before the frontend changes.